### PR TITLE
Daily Withdrawal Limit Smart Contract

### DIFF
--- a/sheran_contract/Clarinet.toml
+++ b/sheran_contract/Clarinet.toml
@@ -10,6 +10,11 @@ path = 'contracts/NFT_backed.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.daily_withdrawal_limit_wallet]
+path = 'contracts/daily_withdrawal_limit_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.distribution_fund]
 path = 'contracts/distribution_fund.clar'
 clarity_version = 2

--- a/sheran_contract/contracts/daily_withdrawal_limit_wallet.clar
+++ b/sheran_contract/contracts/daily_withdrawal_limit_wallet.clar
@@ -1,0 +1,177 @@
+;; Daily Withdrawal Limit Wallet Contract
+;; A smart contract that limits daily withdrawals per user
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-insufficient-balance (err u101))
+(define-constant err-daily-limit-exceeded (err u102))
+(define-constant err-invalid-amount (err u103))
+(define-constant err-transfer-failed (err u104))
+
+;; Default daily limit (in microSTX, 1 STX = 1,000,000 microSTX)
+(define-constant default-daily-limit u10000000) ;; 10 STX
+
+;; Data Variables
+(define-data-var contract-balance uint u0)
+
+;; Data Maps
+;; Track user balances
+(define-map user-balances principal uint)
+
+;; Track daily withdrawal data: amount withdrawn and last withdrawal date
+(define-map daily-withdrawals 
+  principal 
+  {
+    amount-withdrawn: uint,
+    last-withdrawal-day: uint,
+    daily-limit: uint
+  }
+)
+
+;; Private Functions
+
+;; Get current day (block height divided by 144 blocks per day approximately)
+(define-private (get-current-day)
+  (/ block-height u144)
+)
+
+;; Check if it's a new day for the user
+(define-private (is-new-day (user principal))
+  (let ((withdrawal-data (default-to 
+                           {amount-withdrawn: u0, last-withdrawal-day: u0, daily-limit: default-daily-limit}
+                           (map-get? daily-withdrawals user))))
+    (> (get-current-day) (get last-withdrawal-day withdrawal-data))
+  )
+)
+
+;; Reset daily withdrawal counter if it's a new day
+(define-private (reset-daily-counter-if-needed (user principal))
+  (let ((withdrawal-data (default-to 
+                           {amount-withdrawn: u0, last-withdrawal-day: u0, daily-limit: default-daily-limit}
+                           (map-get? daily-withdrawals user))))
+    (if (is-new-day user)
+        (map-set daily-withdrawals user 
+          (merge withdrawal-data {amount-withdrawn: u0, last-withdrawal-day: (get-current-day)}))
+        true
+    )
+  )
+)
+
+;; Public Functions
+
+;; Deposit STX into the wallet
+(define-public (deposit (amount uint))
+  (begin
+    (asserts! (> amount u0) err-invalid-amount)
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (var-set contract-balance (+ (var-get contract-balance) amount))
+    (map-set user-balances tx-sender 
+      (+ (default-to u0 (map-get? user-balances tx-sender)) amount))
+    (ok amount)
+  )
+)
+
+;; Withdraw STX from the wallet (subject to daily limits)
+(define-public (withdraw (amount uint))
+  (let (
+    (user-balance (default-to u0 (map-get? user-balances tx-sender)))
+    (withdrawal-data (default-to 
+                       {amount-withdrawn: u0, last-withdrawal-day: u0, daily-limit: default-daily-limit}
+                       (map-get? daily-withdrawals tx-sender)))
+  )
+    (begin
+      ;; Validate amount
+      (asserts! (> amount u0) err-invalid-amount)
+      (asserts! (<= amount user-balance) err-insufficient-balance)
+      
+      ;; Reset daily counter if needed
+      (reset-daily-counter-if-needed tx-sender)
+      
+      ;; Get updated withdrawal data after potential reset
+      (let ((updated-withdrawal-data (default-to 
+                                       {amount-withdrawn: u0, last-withdrawal-day: (get-current-day), daily-limit: default-daily-limit}
+                                       (map-get? daily-withdrawals tx-sender))))
+        (begin
+          ;; Check daily limit
+          (asserts! (<= (+ (get amount-withdrawn updated-withdrawal-data) amount) 
+                       (get daily-limit updated-withdrawal-data)) 
+                   err-daily-limit-exceeded)
+          
+          ;; Execute withdrawal
+          (try! (as-contract (stx-transfer? amount tx-sender tx-sender)))
+          
+          ;; Update balances and withdrawal tracking
+          (var-set contract-balance (- (var-get contract-balance) amount))
+          (map-set user-balances tx-sender (- user-balance amount))
+          (map-set daily-withdrawals tx-sender 
+            (merge updated-withdrawal-data 
+              {
+                amount-withdrawn: (+ (get amount-withdrawn updated-withdrawal-data) amount),
+                last-withdrawal-day: (get-current-day)
+              }
+            )
+          )
+          
+          (ok amount)
+        )
+      )
+    )
+  )
+)
+
+;; Set custom daily limit for a user (only contract owner can call this)
+(define-public (set-daily-limit (user principal) (new-limit uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (asserts! (> new-limit u0) err-invalid-amount)
+    (let ((withdrawal-data (default-to 
+                             {amount-withdrawn: u0, last-withdrawal-day: u0, daily-limit: default-daily-limit}
+                             (map-get? daily-withdrawals user))))
+      (map-set daily-withdrawals user 
+        (merge withdrawal-data {daily-limit: new-limit}))
+      (ok new-limit)
+    )
+  )
+)
+
+;; Read-only Functions
+
+;; Get user's current balance
+(define-read-only (get-user-balance (user principal))
+  (default-to u0 (map-get? user-balances user))
+)
+
+;; Get user's daily withdrawal information
+(define-read-only (get-daily-withdrawal-info (user principal))
+  (let ((withdrawal-data (default-to 
+                           {amount-withdrawn: u0, last-withdrawal-day: u0, daily-limit: default-daily-limit}
+                           (map-get? daily-withdrawals user))))
+    {
+      amount-withdrawn-today: (if (is-new-day user) u0 (get amount-withdrawn withdrawal-data)),
+      daily-limit: (get daily-limit withdrawal-data),
+      remaining-limit: (if (is-new-day user) 
+                        (get daily-limit withdrawal-data)
+                        (- (get daily-limit withdrawal-data) (get amount-withdrawn withdrawal-data))),
+      last-withdrawal-day: (get last-withdrawal-day withdrawal-data),
+      current-day: (get-current-day)
+    }
+  )
+)
+
+;; Get remaining withdrawal limit for today
+(define-read-only (get-remaining-daily-limit (user principal))
+  (let ((withdrawal-info (get-daily-withdrawal-info user)))
+    (get remaining-limit withdrawal-info)
+  )
+)
+
+;; Get total contract balance
+(define-read-only (get-contract-balance)
+  (var-get contract-balance)
+)
+
+;; Get contract owner
+(define-read-only (get-contract-owner)
+  contract-owner
+)

--- a/sheran_contract/tests/daily_withdrawal_limit_wallet.test.ts
+++ b/sheran_contract/tests/daily_withdrawal_limit_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Daily Withdrawal Limit Wallet — README

## Summary

`Daily Withdrawal Limit Wallet` is a Stacks (Clarity-like) smart contract that holds STX on behalf of users and enforces a per-user daily withdrawal limit. It tracks per-user balances, per-user daily withdrawal amounts and the per-user daily limit (defaults to 10 STX). The contract owner can set custom daily limits for any user.

---

## Key concepts

* **Units:** All monetary values use **microSTX** (1 STX = 1,000,000 microSTX).
  The default daily limit is `default-daily-limit = u10000000` → **10 STX**.
* **Day calculation:** "Day" is approximated by `block-height / 144` (assumes ≈144 blocks/day).
* **Owner:** `contract-owner` is set to `tx-sender` at contract deployment time (the deployer).
* **Daily reset:** Each user's daily withdrawn amount is reset when the current day is greater than their stored `last-withdrawal-day`.

---

## Features

* Deposit STX into the contract and credit the sender's wallet balance.
* Withdraw STX up to the user's remaining per-day limit and available balance.
* Owner-only function to set a custom daily limit for a given user.
* Read-only helpers to fetch per-user balances, daily withdrawal info, remaining daily limit, contract balance, and owner.

---

## Storage layout

### Data variables

* `contract-balance : uint` — total STX held by contract.

### Maps

* `user-balances : principal -> uint` — on-chain tracking of each user's deposit balance.
* `daily-withdrawals : principal -> { amount-withdrawn: uint, last-withdrawal-day: uint, daily-limit: uint }` — per-user daily withdrawal state and limit.

---

## Public functions (API)

### `deposit(amount: uint) : (response uint uint)`

* Validates `amount > 0`.
* Transfers `amount` STX from `tx-sender` to the contract (via `stx-transfer?`).
* Increases `contract-balance` and the sender's `user-balances`.
* Returns `ok amount` on success.

**Notes:** `amount` is in microSTX.

---

### `withdraw(amount: uint) : (response uint uint)`

* Validates `amount > 0` and `amount <= user-balance`.
* Calls `reset-daily-counter-if-needed(tx-sender)` which will reset `amount-withdrawn` to `0` and set `last-withdrawal-day` to current day if the day advanced.
* Ensures `(amount + amount-withdrawn-today) <= daily-limit`.
* Performs STX transfer to the user and updates `contract-balance`, `user-balances`, and `daily-withdrawals`.
* Returns `ok amount` on success.

**Errors returned:**

* `err-invalid-amount` (u103) — amount must be > 0
* `err-insufficient-balance` (u101) — amount exceeds stored user balance
* `err-daily-limit-exceeded` (u102) — would exceed daily limit
* `err-transfer-failed` (u104) — transfer failed

---

### `set-daily-limit(user: principal, new-limit: uint) : (response uint uint)`

* **Owner-only:** callable only by `contract-owner`.
* Validates `new-limit > 0`.
* Writes `daily-limit` into `daily-withdrawals[user]` (merging with existing metadata).
* Returns `ok new-limit`.

**Errors returned:**

* `err-owner-only` (u100) — not owner
* `err-invalid-amount` (u103) — limit must be > 0

---

## Read-only functions

* `get-user-balance(user: principal) -> uint`
  Returns stored balance (microSTX).

* `get-daily-withdrawal-info(user: principal) -> { amount-withdrawn-today, daily-limit, remaining-limit, last-withdrawal-day, current-day }`
  Returns a snapshot of the user's withdrawal state and computed remaining daily limit. If it is a **new day** for the user, `amount-withdrawn-today` is reported as `0` and `remaining-limit == daily-limit`.

* `get-remaining-daily-limit(user: principal) -> uint`
  Convenience: returns the `remaining-limit` for the user.

* `get-contract-balance() -> uint`
  Returns `contract-balance`.

* `get-contract-owner() -> principal`
  Returns `contract-owner`.

---

## Example usage (conceptual)

> All amounts below are in **microSTX**.

1. User deposits 5 STX: call `deposit(5000000)`.

   * Contract balance increases by `5000000`.
   * `user-balances[user]` increases by `5000000`.

2. User attempts to withdraw 8 STX: call `withdraw(8000000)`.

   * If user balance < 8 STX → `err-insufficient-balance`.
   * If user has already withdrawn 3 STX today and daily limit is 10 STX → allowed (3 + 8 = 11 > limit) → `err-daily-limit-exceeded`.

3. Owner sets user limit to 20 STX: `set-daily-limit(user, 20000000)`.

---

## Assumptions & Implementation notes

* `get-current-day` uses `(/ block-height u144)`. That approximates days by block-height with 144 blocks ≈ 1 day; if your chain's block cadence differs significantly, adjust this constant.
* `contract-owner` is assigned at deploy time by `define-constant contract-owner tx-sender`. That means the deployer is the owner and owner cannot be changed by this contract (no setter provided).
* Daily reset is performed lazily on `withdraw` (and implicitly reflected by `get-daily-withdrawal-info`) using `reset-daily-counter-if-needed`. If a user never interacts after midnight, their `amount-withdrawn` remains stored until next interaction.
* The contract stores per-user `daily-limit` inside `daily-withdrawals` map entry. New users default to `default-daily-limit`.

---

## Security considerations & suggestions

* **Re-entrancy / transfer patterns:** Use `try! (stx-transfer? ...)` and perform state writes in the correct order. Clarity's execution model prevents typical EVM re-entrancy, but always test edge cases.
* **As-contract transfers:** Check your `stx-transfer?` usage — be sure the semantics match how you intend to send/receive funds (the contract sends funds out with the appropriate `as-contract`/principal).
* **Time granularity:** The day calculation is approximate. If you need real-world day boundaries (UTC midnight), consider storing block timestamp if available or integrate an oracle or off-chain scheduler.
* **Owner privilege:** Owner can increase user limits. If that is sensitive, consider multi-owner or governance controls.
* **Overflow:** Clarity uses arbitrary precision uints; still write tests for extreme values.

---

## Testing checklist

* Deposit flow: valid and invalid amounts, check stored balances.
* Withdraw flow:

  * withdraw ≤ balance and ≤ remaining limit → success.
  * withdraw > balance → `err-insufficient-balance`.
  * withdraw causes daily total to exceed limit → `err-daily-limit-exceeded`.
  * daily counter resets correctly across simulated day boundary (advance `block-height`).
* `set-daily-limit`:

  * owner can set limit.
  * non-owner fails with `err-owner-only`.
  * invalid limit (0) fails.
* Read-only getters return expected values after operations.
* Edge cases: multiple small withdrawals in same day; withdrawals that exactly match remaining limit.

---

## Potential improvements

* Add an `owner-transfer` or `withdraw-contract` helper for owner to reclaim accidentally-sent funds (with caution).
* Provide an owner function to transfer ownership.
* Emit events/logs (if supported) for deposit/withdrawal/limit changes.
* Add unit tests that manipulate `block-height` to simulate days passing.
* Allow users to request a limit increase that the owner can approve, enabling an on-chain flow with audit.

---

## License

MIT.

---